### PR TITLE
fixes self is undefined error in loadTemplates

### DIFF
--- a/src/plugins/kibi_core/lib/query_engine.js
+++ b/src/plugins/kibi_core/lib/query_engine.js
@@ -89,7 +89,7 @@ QueryEngine.prototype.loadTemplates = function () {
     self._loadTemplates();
   }).catch(function (err) {
     self.log.warn('Kibi index NOT found');
-    setTimeout(self.loadTemplates, 500);
+    setTimeout(self.loadTemplates.bind(self), 500);
   });
 };
 


### PR DESCRIPTION
Addresses symptoms of #21 (i.e., crashing when re-trying to load templates).

However, the root cause for having to retry in the first place seems to be the request timeout in `_isKibiIndexPresent`, which is apparently too short.
