### PR TITLE
fixes kibi index presence check

### DIFF
--- a/src/plugins/kibi_core/lib/query_engine.js
+++ b/src/plugins/kibi_core/lib/query_engine.js
@@ -103,7 +103,7 @@ QueryEngine.prototype._isKibiIndexPresent =  function () {
     headers: {
       'content-type': 'application/json'
     },
-    timeout: 1000
+    timeout: 2000
   }).then(function (indexes) {
     var kibiIndex = _.find(indexes, function (index) {
       return index.index === self.config.get('kibana.index');


### PR DESCRIPTION
As reported in #21, `_isKibiIndexPresent` fails repeatedly. In fact, it never worked in my setup—it always timed out.

This is not a real solution, but a workaround. Maybe some sort of backoff algorithm could be used?
