### PR TITLE
support for scripted metric (exp)

### DIFF
--- a/src/ui/public/agg_types/index.js
+++ b/src/ui/public/agg_types/index.js
@@ -13,7 +13,8 @@ define(function (require) {
         Private(require('ui/agg_types/metrics/stdDeviation')),
         Private(require('ui/agg_types/metrics/cardinality')),
         Private(require('ui/agg_types/metrics/percentiles')),
-        Private(require('ui/agg_types/metrics/percentile_ranks'))
+        Private(require('ui/agg_types/metrics/percentile_ranks')),
+        Private(require('ui/agg_types/metrics/scripted_metric'))
       ],
       buckets: [
         Private(require('ui/agg_types/buckets/date_histogram')),
@@ -63,3 +64,4 @@ define(function (require) {
   // preload
   require('ui/agg_types/AggParams');
 });
+

--- a/src/ui/public/agg_types/metrics/scripted_metric.js
+++ b/src/ui/public/agg_types/metrics/scripted_metric.js
@@ -1,0 +1,44 @@
+define(function (require) {
+
+  return function AggTypeMetricScriptedMetricProvider(Private) {
+    var _ = require('lodash');
+
+    // KBN 5
+    // var MetricAggType = Private(require('ui/agg_types/metrics/metric_agg_type'));
+
+    var MetricAggType = Private(require('ui/agg_types/metrics/MetricAggType'));
+    var fieldFormats = Private(require('ui/registry/field_formats'));
+    var stringEditor = require('ui/agg_types/controls/string.html');
+
+    return new MetricAggType({
+      name: 'scripted_metric',
+      title: 'Scripted Metric',
+      makeLabel: function (aggConfig) {
+        return aggConfig.params.field.displayName;
+      },
+      getFormat: function () {
+        return fieldFormats.getDefaultInstance('number') || fieldFormats.getDefaultInstance('percent');
+      },
+      supportsOrderBy: false,
+      params: [
+        {
+          name: 'init_script',
+          editor: stringEditor,
+          default: ''
+        }, {
+          name: 'map_script',
+          editor: stringEditor,
+          default: ''
+        }, {
+          name: 'combine_script',
+          editor: stringEditor,
+          default: ''
+        }, {
+          name: 'reduce_script',
+          editor: stringEditor,
+          default: ''
+        }
+      ]
+    });
+  };
+});


### PR DESCRIPTION
This PR implements basic support to play with the [Scripted Metric Aggregations](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-aggregations-metrics-scripted-metric-aggregation.html) _experimental_ feature available in Elasticsearch _2.x_ and _5.x_ 

The feature is an alternative to static Kibana scripted fields by using scripts to provide metric output.

Needs review, testing & regression test cases, posting as a proposal to those interested in giving it a shot.

Source: https://github.com/elasticfence/kibana-scripted-metric
